### PR TITLE
ida: track file offsets

### DIFF
--- a/plugin/ida/ibis.py
+++ b/plugin/ida/ibis.py
@@ -60,7 +60,7 @@ def add_segment(
 ):
     if file_offset is not None and input_size:
         size = min(size, input_size - file_offset)
-        fd.file2base(file_offset, ea, ea + size, False)
+        fd.file2base(file_offset, ea, ea + size, ida_loader.FILEREG_PATCHABLE)
 
     segm = ida_segment.segment_t()
     segm.bitness = 2  # 64-bit


### PR DESCRIPTION
`file2base`'s `patchable` parameter controls whether the ida kernel will keep track of the mapping between input file offsets and the corresponding linear addresses.

see https://github.com/HexRaysSA/ida-sdk/blob/85aa28e8a455d995308b417d101671495e14fb2a/src/include/loader.hpp#L394

fixes https://github.com/jonpalmisc/ibis/issues/7