### PR TITLE
Create installation directory if it does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,12 @@ all:
 
 .PHONY: install-binja
 install-binja:
+	mkdir -p $(BN_PLUGINS_PATH)
 	$(LN) $(shell pwd)/plugin/binja $(BN_PLUGINS_PATH)/view_ibis
 
 .PHONY: install-ida
 install-ida:
+	mkdir -p $(IDA_LOADERS_PATH)
 	$(LN) $(shell pwd)/plugin/ida/ibis.py $(IDA_LOADERS_PATH)/ibis.py
 
 .PHONY: uninstall


### PR DESCRIPTION
Installation using Makefile can fail if `BN_PLUGINS_PATH` or `IDA_LOADERS_PATH` do not exist beforehand. We should create them if needed.

```
❯ make install-ida
ln -s -f /Users/user/.../ibis/plugin/ida/ibis.py ~/.idapro/loaders/ibis.py
ln: /Users/user/.idapro/loaders/ibis.py: No such file or directory
make: *** [install-ida] Error 1
```